### PR TITLE
Bdog-3638 update legacy urls

### DIFF
--- a/app/uk/gov/hmrc/healthmetrics/connector/ReleasesConnector.scala
+++ b/app/uk/gov/hmrc/healthmetrics/connector/ReleasesConnector.scala
@@ -49,7 +49,7 @@ class ReleasesConnector @Inject() (
       case None                       => Map.empty
 
     httpClientV2
-      .get(url"$url/releases-api/whats-running-where?${params(metricFilter)}")
+      .get(url"$url/api/whats-running-where?${params(metricFilter)}")
       .execute[Seq[WhatsRunningWhere]]
 
 object ReleasesConnector:

--- a/app/uk/gov/hmrc/healthmetrics/connector/SlackNotificationsConnector.scala
+++ b/app/uk/gov/hmrc/healthmetrics/connector/SlackNotificationsConnector.scala
@@ -49,7 +49,7 @@ class SlackNotificationsConnector @Inject()(
     given Writes[Request] = Request.writes
     given Reads[Response] = Response.reads
     httpClientV2
-      .post(url"$baseUrl/slack-notifications/v2/notification")
+      .post(url"$baseUrl/api/v2/notification")
       .withBody:
         Json.toJson(channelOverride.fold(request)(c => request.copy(channelLookup = ChannelLookup.ByChannels(Seq(c)))))
       .setHeader("Authorization" -> token)

--- a/test/uk/gov/hmrc/healthmetrics/connector/ReleasesConnectorSpec.scala
+++ b/test/uk/gov/hmrc/healthmetrics/connector/ReleasesConnectorSpec.scala
@@ -70,7 +70,7 @@ class ReleasesConnectorSpec
 
     "return all releases" in:
       stubFor:
-        WireMock.get(urlEqualTo("/releases-api/whats-running-where"))
+        WireMock.get(urlEqualTo("/api/whats-running-where"))
           .willReturn:
             aResponse()
               .withStatus(200)
@@ -83,7 +83,7 @@ class ReleasesConnectorSpec
 
     "return all releases for a team" in:
       stubFor:
-        WireMock.get(urlEqualTo("/releases-api/whats-running-where?teamName=Team+1"))
+        WireMock.get(urlEqualTo("/api/whats-running-where?teamName=Team+1"))
           .willReturn:
             aResponse()
               .withStatus(200)
@@ -96,7 +96,7 @@ class ReleasesConnectorSpec
 
     "return all releases for a digital service" in:
       stubFor:
-        WireMock.get(urlEqualTo("/releases-api/whats-running-where?digitalService=Digital+Service+1"))
+        WireMock.get(urlEqualTo("/api/whats-running-where?digitalService=Digital+Service+1"))
           .willReturn:
             aResponse()
               .withStatus(200)

--- a/test/uk/gov/hmrc/healthmetrics/connector/SlackNotificationsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/healthmetrics/connector/SlackNotificationsConnectorSpec.scala
@@ -42,7 +42,7 @@ class SlackNotificationsConnectorSpec
         val expectedResponse = SlackNotificationsConnector.Response(errors = Nil)
 
         stubFor(
-          post(urlEqualTo("/slack-notifications/v2/notification"))
+          post(urlEqualTo("/api/v2/notification"))
             .willReturn(
               aResponse()
                 .withStatus(200)
@@ -84,7 +84,7 @@ class SlackNotificationsConnectorSpec
         response shouldBe expectedResponse
 
         verify(
-          postRequestedFor(urlEqualTo("/slack-notifications/v2/notification"))
+          postRequestedFor(urlEqualTo("/api/v2/notification"))
             .withRequestBody(equalToJson(
               """{
              "channelLookup": {


### PR DESCRIPTION
Update whats-running-where and slack-notification URL usages to current version.