### PR TITLE
Bdog 3638 revert wrong url

### DIFF
--- a/app/uk/gov/hmrc/healthmetrics/connector/ReleasesConnector.scala
+++ b/app/uk/gov/hmrc/healthmetrics/connector/ReleasesConnector.scala
@@ -49,7 +49,7 @@ class ReleasesConnector @Inject() (
       case None                       => Map.empty
 
     httpClientV2
-      .get(url"$url/api/whats-running-where?${params(metricFilter)}")
+      .get(url"$url/releases-api/whats-running-where?${params(metricFilter)}")
       .execute[Seq[WhatsRunningWhere]]
 
 object ReleasesConnector:

--- a/test/uk/gov/hmrc/healthmetrics/connector/ReleasesConnectorSpec.scala
+++ b/test/uk/gov/hmrc/healthmetrics/connector/ReleasesConnectorSpec.scala
@@ -107,7 +107,7 @@ class ReleasesConnectorSpec
         .futureValue
         .shouldBe(expectedReleases)
 
-  private val whatsRunningWhereJson: String =
+  private lazy val whatsRunningWhereJson: String =
     """[
       {
         "applicationName": "application-1",

--- a/test/uk/gov/hmrc/healthmetrics/connector/ReleasesConnectorSpec.scala
+++ b/test/uk/gov/hmrc/healthmetrics/connector/ReleasesConnectorSpec.scala
@@ -70,7 +70,7 @@ class ReleasesConnectorSpec
 
     "return all releases" in:
       stubFor:
-        WireMock.get(urlEqualTo("/api/whats-running-where"))
+        WireMock.get(urlEqualTo("/releases-api/whats-running-where"))
           .willReturn:
             aResponse()
               .withStatus(200)
@@ -83,7 +83,7 @@ class ReleasesConnectorSpec
 
     "return all releases for a team" in:
       stubFor:
-        WireMock.get(urlEqualTo("/api/whats-running-where?teamName=Team+1"))
+        WireMock.get(urlEqualTo("/releases-api/whats-running-where?teamName=Team+1"))
           .willReturn:
             aResponse()
               .withStatus(200)
@@ -96,7 +96,7 @@ class ReleasesConnectorSpec
 
     "return all releases for a digital service" in:
       stubFor:
-        WireMock.get(urlEqualTo("/api/whats-running-where?digitalService=Digital+Service+1"))
+        WireMock.get(urlEqualTo("/releases-api/whats-running-where?digitalService=Digital+Service+1"))
           .willReturn:
             aResponse()
               .withStatus(200)


### PR DESCRIPTION
Needed to revert previous PR https://github.com/hmrc/health-metrics/pull/17 as the updated URL was incorrect.
This is an internal service so does not go via platops-api which uses `/api` prefix. 